### PR TITLE
Remove backdrop

### DIFF
--- a/SimpleArmory.xml
+++ b/SimpleArmory.xml
@@ -4,17 +4,6 @@
   <Size>
     <AbsDimension x="700" y="450"/>
   </Size>
-  <Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-    <BackgroundInsets>
-      <AbsInset left="5" right="5" top="5" bottom="5"/>
-    </BackgroundInsets>
-    <TileSize>
-      <AbsValue val="16"/>
-    </TileSize>
-    <EdgeSize>
-      <AbsValue val="16"/>
-    </EdgeSize>
-  </Backdrop>
   <Layers>
     <Layer level="ARTWORK">
       <FontString name="SAText" inherits="GameFontHighlight">


### PR DESCRIPTION
Backdrop is no longer a part of the World of Warcraft API.
https://wowpedia.fandom.com/wiki/XML/Backdrop

This should resolve #6 
You might want to increase the version number after/before merging